### PR TITLE
Fix numpy error pertaining to np.Inf

### DIFF
--- a/pipelines/utils/early_stopping.py
+++ b/pipelines/utils/early_stopping.py
@@ -28,7 +28,7 @@ class EarlyStopping:
         self.counter = 0
         self.best_score: Optional[float] = None
         self.early_stop = False
-        self.val_loss_min = np.Inf
+        self.val_loss_min = np.inf
         self.delta = delta
         self.model_filename = model_save_path
         if not model_save_path.endswith(".pt"):


### PR DESCRIPTION
With newer versions of numpy we get the following error since the attribute is now np.inf (not np.Inf).
This fixes that.
```
$ python -m examples.moving_mnist_convlstm

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/lukasgenshiro.nakamura/code/SA-ConvLSTM-Pytorch/examples/moving_mnist_convlstm.py", line 68, in <module>
    main()
  File "/Users/lukasgenshiro.nakamura/code/SA-ConvLSTM-Pytorch/examples/moving_mnist_convlstm.py", line 46, in main
    "early_stopping": EarlyStopping(
                      ^^^^^^^^^^^^^^
  File "/Users/lukasgenshiro.nakamura/code/SA-ConvLSTM-Pytorch/pipelines/utils/early_stopping.py", line 31, in __init__
    self.val_loss_min = np.Inf
                        ^^^^^^
  File "/Users/lukasgenshiro.nakamura/.pyenv/versions/3.11.0/lib/python3.11/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.. Did you mean: 'inf'?
```